### PR TITLE
Add -a arg to the grep invocation to properly process non-ASCII filenames

### DIFF
--- a/git-splits
+++ b/git-splits
@@ -64,7 +64,7 @@ fi
 for var in "$@"
 do
 
-	dirs="| grep -z -v \"^$var\" \
+	dirs="| grep -a -z -v \"^$var\" \
 	$dirs"
 
 done


### PR DESCRIPTION
Trying to invoke splits on a repo which has non-ASCII filenames yields
"Binary file (standard input) matches"
, and a fatal git crash.
The -a argument makes things work.
