### PR TITLE
Fixed single line installation command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Note that this operation is very I/O expensive. If your repository is large, it 
 
 Execute the following one-liner from a bash shell on your local machine.
 
-    wget -o $(dirname $(which git))/git-splits https://github.com/simpliwp/git-splits/blob/master/git-splits;chmod o+x $(dirname $(which git))/git-splits;
+    wget -O $(dirname $(which git))/git-splits https://github.com/simpliwp/git-splits/blob/master/git-splits;chmod o+x $(dirname $(which git))/git-splits;
 
 This will download a copy to the same directory that the git binary is located in, and set the executable bit for the owner.
 


### PR DESCRIPTION
wget switch was incorrect. `-o` saves command output, i.e. request information to the file